### PR TITLE
Title: Feat/user_password_change

### DIFF
--- a/exception_al/exception_al/urls.py
+++ b/exception_al/exception_al/urls.py
@@ -16,12 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework.authtoken.views import obtain_auth_token
+from user.views import CustomAuthToken
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include ('user.urls')),
     path('api-auth/', include('rest_framework.urls')),
-    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
-
+    path('api-token-auth/', CustomAuthToken.as_view(), name='api_token_auth')
 ]

--- a/exception_al/user/serializers.py
+++ b/exception_al/user/serializers.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 from .models import CustomUser, Skill, Interest
@@ -36,3 +37,33 @@ class CustomUserSerializer(serializers.ModelSerializer):
         user.profile_image = validated_data.get('profile_image', '')
         user.save()
         return user
+
+# code source modified from https://medium.com/django-rest/django-rest-framework-change-password-and-update-profile-1db0c144c0a3
+    
+class ChangePasswordSerializer(serializers.ModelSerializer):
+    new_password = serializers.CharField(write_only=True, required=True, validators=[validate_password])
+    new_password2 = serializers.CharField(write_only=True, required=True)
+    password = serializers.CharField(write_only=True, required=True)
+
+    class Meta:
+        model = CustomUser
+        fields = ('password', 'new_password', 'new_password2')
+
+    def validate(self, attrs):
+        if attrs['new_password'] != attrs['new_password2']:
+            raise serializers.ValidationError({"password": "Password fields do not match."})
+
+        return attrs
+
+    def validate_password(self, value):
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise serializers.ValidationError({"password": "Existing password is not correct"})
+        return value
+
+    def update(self, instance, validated_data):
+
+        instance.set_password(validated_data['password'])
+        instance.save()
+
+        return instance

--- a/exception_al/user/urls.py
+++ b/exception_al/user/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('users/', views.CustomUserList.as_view()),
     path('user/register', views.CustomUserRegister.as_view()),
     path('user/<int:pk>/', views.CustomUserDetail.as_view()),
+    path('user/change_password/<int:pk>/', views.ChangePasswordView.as_view())
 ]


### PR DESCRIPTION
Body:

- corrects the url in exception_al/urls.py to path(‘api-token-auth/’, views.CustomAuthToken.as_view(), name=‘api_token_auth’)
- adds change password function to user serializers, view and urls

Tested the following API endpoint:
PUT /user/change_password/<int_pk>/
![image](https://github.com/SheCodesAus/2024_exception_al_back_end/assets/146698245/be6df7ca-04de-48fd-8a8e-60d0bc0d4439)

User must be authenticated and provide current password and new password, re-entered new password. If both new passwords match, new auth token generated.



